### PR TITLE
Set errexit option

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o errexit
+
 #
 # This script checks if image already exist in registry, if not it will build and tag image
 # 


### PR DESCRIPTION
If any of these commands fail, abort fast, so as not to waste any time.

Also, presumably it would be easier to spot the problem easier if the build does not carry on.